### PR TITLE
Add DoenetML Specific Syntax Highlighting

### DIFF
--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -1,3 +1,4 @@
+import { Link } from "nextra-theme-docs";
 import React from "react";
 
 export type PropAttrType =
@@ -37,9 +38,11 @@ export type PropInfo = {
 export function AttrDisplay({
     name,
     attrs = [],
+    links = {},
 }: {
     name: string;
     attrs: AttrInfo[];
+    links?: Record<string, string>;
 }) {
     attrs.sort((a, b) => a.name.localeCompare(b.name));
     const commonAttrs = attrs.filter((attr) => attr.common);
@@ -63,26 +66,36 @@ export function AttrDisplay({
                 </tr>
             </thead>
             <tbody>
-                {componentAttrs.map((attr) => (
-                    <tr key={attr.name}>
-                        <td>
-                            <code>
-                                <span className="attr-name">{attr.name}</span>
-                                 = "…"
-                            </code>
-                        </td>
-                        <td className="attr-type">
-                            {formatType(attr.type, attr.isArray)}
-                        </td>
-                        <td className="attr-values">
-                            {attr.values?.map((v) => (
-                                <React.Fragment key={v}>
-                                    <code className="attr-value">"{v}"</code>{" "}
-                                </React.Fragment>
-                            )) || ""}
-                        </td>
-                    </tr>
-                ))}
+                {componentAttrs.map((attr) => {
+                    const linkTarget = links[attr.name];
+                    const nameElm = linkTarget ? (
+                        <Link href={linkTarget}>{attr.name}</Link>
+                    ) : (
+                        attr.name
+                    );
+                    return (
+                        <tr key={attr.name}>
+                            <td>
+                                <code>
+                                    <span className="attr-name">{nameElm}</span>
+                                     = "…"
+                                </code>
+                            </td>
+                            <td className="attr-type">
+                                {formatType(attr.type, attr.isArray)}
+                            </td>
+                            <td className="attr-values">
+                                {attr.values?.map((v) => (
+                                    <React.Fragment key={v}>
+                                        <code className="attr-value">
+                                            "{v}"
+                                        </code>{" "}
+                                    </React.Fragment>
+                                )) || ""}
+                            </td>
+                        </tr>
+                    );
+                })}
             </tbody>
         </table>
     );
@@ -91,9 +104,11 @@ export function AttrDisplay({
 export function PropDisplay({
     name,
     props = [],
+    links = {},
 }: {
     name: string;
     props: PropInfo[];
+    links?: Record<string, string>;
 }) {
     props.sort((a, b) => a.name.localeCompare(b.name));
     const commonProps = props.filter((attr) => attr.common);
@@ -116,19 +131,25 @@ export function PropDisplay({
                 </tr>
             </thead>
             <tbody>
-                {componentProps.map((prop) => (
-                    <tr key={prop.name}>
+                {componentProps.map((prop) => {
+                    const linkTarget = links[prop.name];
+                    const nameElm = linkTarget ? (
+                        <Link href={linkTarget}>{prop.name}</Link>
+                    ) : (
+                        prop.name
+                    );
+                    return <tr key={prop.name}>
                         <td>
                             <code>
                                 ${refName}.
-                                <span className="prop-name">{prop.name}</span>
+                                <span className="prop-name">{nameElm}</span>
                             </code>
                         </td>
                         <td className="prop-type">
                             {formatType(prop.type, prop.isArray)}
                         </td>
                     </tr>
-                ))}
+                })}
             </tbody>
         </table>
     );

--- a/packages/docs-nextra/pages/reference/doenetML_components/angle.mdx
+++ b/packages/docs-nextra/pages/reference/doenetML_components/angle.mdx
@@ -12,29 +12,28 @@ When reference lines or points are used to specify the `<angle>`, two possibliti
 
 ## Attributes and Properties
 
-<AttrDisplay name="angle" />
-<PropDisplay name="angle" />
+<AttrDisplay name="angle" links={{
+  radius: "#radius-ex",
+  chooseReflexAngle: "#chooseReflexAngle-ex",
+  inDegrees: "#inDegrees-ex",
+  through: "#threePoints-ex",
+  radians: "#radians-ex",
+  betweenLines: "#twoLines-ex",
+  emphasizeRightAngle: "#emphasizeRightAngle-ex",
+}} />
 
-**Attributes**
-* [radius](#radius-ex)
-* [chooseReflexAngle](#chooseReflexAngle-ex)
-* [inDegrees](#inDegrees-ex)
-* [radians](#radians-ex)
-* [through](#threePoints-ex)
-* [betweenLines](#twoLines-ex)
-* [emphasizeRightAngle](#emphasizeRightAngle-ex)
+<PropDisplay name="angle" links={{
+  angle: "#angle-ex",
+  value: "#angle-ex",
+}} />
 
-**Properties**
-* [attributes as properties](#attributesAsProps-ex)
-* [angle, value](#angle-ex)
-
-## Example list
+## Examples
 1. [`<angle>` between two lines](#twoLines-ex)
 2. [`<angle>` between three points](#threePoints-ex)
 3. [`<angle>` specified by user-input](#userInput-ex)
 
 <a id="twoLines-ex"></a>
-### Example: `<angle>` between two lines
+### Example: `<angle>{:html}` between two lines
 ```html {4}
 <graph size="small" xmax="6" ymin="-6">
   <line name="line1">y = 1/2 x + 4</line>

--- a/packages/docs-nextra/pages/reference/doenetML_components/angle.mdx
+++ b/packages/docs-nextra/pages/reference/doenetML_components/angle.mdx
@@ -33,19 +33,19 @@ When reference lines or points are used to specify the `<angle>`, two possibliti
 3. [`<angle>` specified by user-input](#userInput-ex)
 
 <a id="twoLines-ex"></a>
-### Example: `<angle>{:html}` between two lines
-```html {4}
+### Example: `<angle>{:dn}` between two lines
+```dn {4}
 <graph size="small" xmax="6" ymin="-6">
   <line name="line1">y = 1/2 x + 4</line>
   <line name="line2">y = -x  - 1</line>
   <angle betweenLines="$line1 $line2" radius="3"/>
 </graph>
 ```
-Two lines are created within a `<graph>` using the `<line>` component. The `<angle>` component is specified by referencing those lines by name with the betweenLines attribute. Test code [here](#test-code).
+Two lines are created within a `<graph>{:dn}` using the `<line>{:dn}` component. The `<angle>{:dn}` component is specified by referencing those lines by name with the betweenLines attribute. Test code [here](#test-code).
 
 <a id="threePoints-ex"></a>
 ### Example: `<angle>` between three points
-```html
+```dn
 <graph size="small" xmin="-6" xmax="6" ymin="-6" ymax="6">
   <angle through="(5,-3) (0,0) (5,4)"/>
 </graph>
@@ -54,17 +54,17 @@ Three points define the angle with the `through` attribute. Test code [here](#te
 
 <a id="userInput-ex"></a>
 ### Example: `<angle>` specified by user-input
-```html {3}
+```dn {3}
 Angle in radians: <mathInput name="userAngle"/>
 <graph size="small" xmin="-3" xmax="3" ymin="-3" ymax="3">
   <angle>$userAngle</angle>
 </graph>
 ```
-The user is prompted to enter an angle with the `<mathInput/>` component. This angle is then referenced by name within the opening and closing `<angle>` tags. Test code [here](#test-code).
+The user is prompted to enter an angle with the `<mathInput/>{:dn}` component. This angle is then referenced by name within the opening and closing `<angle>{:dn}` tags. Test code [here](#test-code).
 
 <a id="radius-ex"></a>
 ### Example: `radius` attribute
-```html
+```dn
 <graph size="small">
   <angle degrees="65" radius="5"/>
 </graph>
@@ -73,7 +73,7 @@ The `radius` attribute is used to change the radius of the angle symbol shown on
 
 <a id="chooseReflexAngle-ex"></a>
 ### Example: `chooseReflexAngle` attribute
-```html {5,6,7}
+```dn {5,6,7}
 <graph>
   <point name="A" fixed>(5, -3)</point>
   <point name="B" fixed>(0, 0)</point>
@@ -94,7 +94,7 @@ Finally, the orange angle takes the specified through-points in a counter-clockw
 
 <a id="inDegrees-ex"></a>
 ### Example: `inDegrees` attribute
-```html
+```dn
 <graph size="small" xmin="-3" xmax="3" ymin="-3" ymax="3">
   <angle name="a" inDegrees degrees="30"/>
 </graph>
@@ -104,7 +104,7 @@ The `inDegrees` attribute specifies that the output of the angle when defined or
 
 <a id="degrees-ex"></a>
 ### Example: `degrees` attribute
-```html
+```dn
 <graph size="small" xmin="-3" xmax="3" ymin="-3" ymax="3">
   <angle degrees="30"/>
 </graph>
@@ -113,7 +113,7 @@ The `degrees` attribute specifies the measure of the angle in degrees; type = ma
 
 <a id="radians-ex"></a>
 ### Example: `radians` attribute
-```html
+```dn
 <graph size="small" xmin="-3" xmax="3" ymin="-3" ymax="3">
   <angle radians="pi/2"/>
 </graph>
@@ -123,7 +123,7 @@ The `radians` attribute specifies the measure of the angle in radians; type = ma
 
 <a id="emphasizeRightAngle-ex"></a>
 ### Example: `emphasizeRightAngle` attribute
-```html
+```dn
 <graph size="small" xmin="-3" xmax="3" ymin="-3" ymax="3">
   <angle radians="pi/2" emphasizeRightAngle="false"/>
 </graph>
@@ -132,7 +132,7 @@ By default, right angles are shown with a square symbol. Use the emphasizeRightA
 
 <a id="attributesAsProps-ex"></a>
 ### Example: attributes as properties
-```html
+```dn
 <graph size="small" xmin="-3" xmax="3" ymin="-3" ymax="3">
   <angle name="alpha" radians="pi/2"/>
 </graph>
@@ -148,7 +148,7 @@ The attributes listed above are also accessible as properties. Test code [here](
 
 <a id="angle-ex"></a>
 ### Example: angle, value properties
-```html
+```dn
 <graph size="small" xmin="-3" xmax="3" ymin="-3" ymax="3">
   <angle name="alpha" radians="pi/2"/>
 </graph>

--- a/packages/vscode-extension/extension/config/doenet.tmLanguage.json
+++ b/packages/vscode-extension/extension/config/doenet.tmLanguage.json
@@ -251,6 +251,9 @@
                 },
                 {
                     "include": "#bare-ampersand"
+                },
+                {
+                    "include": "#variable"
                 }
             ]
         },
@@ -319,6 +322,9 @@
                 },
                 {
                     "include": "#bare-ampersand"
+                },
+                {
+                    "include": "#variable"
                 }
             ]
         },
@@ -385,7 +391,7 @@
         },
         "variable": {
             "match": "(\\$)(\\w+(\\[.*?\\])?)(\\.(\\w+(\\[.*?\\])?))*(\\{.*?\\})?",
-            "name": "variable.other.doenet"
+            "name": "variable.language.doenet"
         }
     }
 }


### PR DESCRIPTION
This PR adds a `doenet` and `dn` modes for code blocks that uses the doenetml textmate grammar to syntax highlight the doenet code. This is better than using `html` mode, since `html` mode highlights in red tags that are not valid HTLM. We also get highlighted variables!

![image](https://github.com/virginiaMae/DoenetML/assets/839083/edaca285-782b-4c3f-957b-0a5de61cb4b8)
